### PR TITLE
support multiple query fields

### DIFF
--- a/service/models.py
+++ b/service/models.py
@@ -169,17 +169,22 @@ class Promotion(db.Model):
         return cls.query.filter(cls.title == title)
 
     @classmethod
-    def find_by_field(cls, field_name, value):
-        """Returns all Promotions with the value for the field_name
+    def find_by_fields(cls, query_params):
+        """Returns all Promotions that match all field values provided in query_params.
 
         Args:
-            field_name (string): the field you want to get value for
-            value: the value to match for
-        """
-        if not hasattr(cls, field_name):
-            raise DataValidationError(
-                f"Field '{field_name}' is not a valid attribute of {cls.__name__}."
-            )
+            query_params (dict): A dictionary where keys are field names and values are the values to match for.
 
-        logger.info("Processing filter query for %s = %s ...", field_name, value)
-        return cls.query.filter(getattr(cls, field_name) == value).all()
+        Raises:
+            DataValidationError: If any field in query_params is not a valid attribute of the model.
+        """
+        query = cls.query
+        for field_name, value in query_params.items():
+            if not hasattr(cls, field_name):
+                raise DataValidationError(
+                    f"Field '{field_name}' is not a valid attribute of {cls.__name__}."
+                )
+            query = query.filter(getattr(cls, field_name) == value)
+
+        logger.info("Processing filter query with parameters: %s", query_params)
+        return query.all()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -187,29 +187,22 @@ class TestPromotion(TestCase):
         promotion = PromotionFactory()
         promotion.create()
         self.assertIsNotNone(promotion.id)
-        title_found = Promotion.find_by_field("title", promotion.title)
-        desc_found = Promotion.find_by_field("description", promotion.description)
-        promo_code_found = Promotion.find_by_field("promo_code", promotion.promo_code)
-        promo_type_found = Promotion.find_by_field("promo_type", promotion.promo_type)
-        promo_value_found = Promotion.find_by_field(
-            "promo_value", promotion.promo_value
-        )
-        start_date_found = Promotion.find_by_field("start_date", promotion.start_date)
-        created_date_found = Promotion.find_by_field(
-            "created_date", promotion.created_date
-        )
-        duration_found = Promotion.find_by_field("duration", promotion.duration)
-        active_found = Promotion.find_by_field("active", promotion.active)
 
-        self.assertEqual(len(title_found), 1)
-        self.assertEqual(len(desc_found), 1)
-        self.assertEqual(len(promo_code_found), 1)
-        self.assertEqual(len(promo_type_found), 1)
-        self.assertEqual(len(promo_value_found), 1)
-        self.assertEqual(len(start_date_found), 1)
-        self.assertEqual(len(created_date_found), 1)
-        self.assertEqual(len(duration_found), 1)
-        self.assertEqual(len(active_found), 1)
+        params_map = {
+            "title": promotion.title,
+            "description": promotion.description,
+            "promo_code": promotion.promo_code,
+            "promo_type": promotion.promo_type,
+            "promo_value": promotion.promo_value,
+            "start_date": promotion.start_date,
+            "created_date": promotion.created_date,
+            "duration": promotion.duration,
+            "active": promotion.active,
+        }
+        data_found = Promotion.find_by_fields(query_params=params_map)
+
+        self.assertEqual(len(data_found), 1)
+        self.assertEqual(data_found[0].id, promotion.id)
 
     def test_query_error_field(self):
         """It should raise error for query because field is not present"""
@@ -218,8 +211,5 @@ class TestPromotion(TestCase):
         promotion.create()
 
         self.assertRaises(
-            DataValidationError,
-            Promotion.find_by_field,
-            "not_present_field",
-            promotion.title,
+            DataValidationError, Promotion.find_by_fields, {"not_present_field": -1}
         )


### PR DESCRIPTION
To use the function find_by_fields, pass in a dictionary where the key is the field name and value is the value to query for. This function supports multiple query fields