### PR TITLE
Add ci badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,15 @@ jobs:
         env:
           DATABASE_URI: "postgresql+psycopg://postgres:postgres@localhost:5432/postgres"
 
-     - name: Upload coverage reports to Codecov
-       uses: codecov/codecov-action@v3.1.4
-       with:
-          token: ${{ secrets.CODECOV_TOKEN }} 
+      - name: Run unit tests with PyTest
+        run: pytest --pspec --cov=service --cov-report=xml --cov-fail-under=95
+        env:
+          DATABASE_URI: "redis://redis:6379"
+  
+        # Create a CODECOV_TOKEN in Settings->Secrets and variables->Actions
+        # and then uncomment the CodeCov action during hands-on lab
+  
+        # - name: Upload coverage reports to Codecov
+        #   uses: codecov/codecov-action@v3.1.4
+        #   with:
+        #     token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Python](https://img.shields.io/badge/Language-Python-blue.svg)](https://python.org/)
+[![Build Status](https://github.com/CSCI-GA-2820-FA24-003/promotions/actions/workflows/ci.yml/badge.svg)](https://github.com/CSCI-GA-2820-FA24-003/promotions/actions)
 
 ## API Usage
 local depolyment: http://localhost:8080/


### PR DESCRIPTION
1. Fix the wrong location of workflows directory and update README.md to add the ci badge.